### PR TITLE
Add Fake TNT and Random Teleport perks

### DIFF
--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
@@ -299,14 +299,16 @@ public class Arena implements Listener {
 
         arenaCuboidArea = new CuboidArea(
                 config.getConfigurationSection("ArenaArea.One"),
-                config.getConfigurationSection("ArenaArea.Two"));
+                config.getConfigurationSection("ArenaArea.Two"),
+                config.get("WorldName").toString());
 
         perkHandler = new PerkHandler(arenaCuboidArea, plugin);
         voteHandler = new VoteHandler();
 
         watchCuboidArea = new CuboidArea(
                 config.getConfigurationSection("WaitArea.One"),
-                config.getConfigurationSection("WaitArea.Two"));
+                config.getConfigurationSection("WaitArea.Two"),
+                config.get("WorldName").toString());
 
         arenaBlocks = new ArenaBlocks(arenaCuboidArea);
     }
@@ -403,13 +405,15 @@ public class Arena implements Listener {
             //TODO should probably be optimized later on
             Random random = new Random();
             ItemStack[] newItems = new ItemStack[]{
+                    Loadout.FAKE_TNT_ITEM.clone(),
                     Loadout.BOOST_ITEM.clone(),
                     Loadout.CHIKUN_ITEM.clone(),
                     Loadout.HOOK_ITEM.clone(),
                     Loadout.INVIS_ITEM.clone(),
                     Loadout.STEAL_ITEM.clone(),
                     Loadout.WEB_ITEM.clone(),
-                    Loadout.TNT_ITEM.clone()};
+                    Loadout.TNT_ITEM.clone(),
+                    Loadout.RANDOM_TP_ITEM.clone()};
             int i, choice, itemIndex;
             ItemStack item;
             int chestItemAmount = 2;
@@ -440,6 +444,7 @@ public class Arena implements Listener {
             Location clicked = clickedBlock.getLocation();
             if (arenaBlocks.getCuboidArea().isInside(clicked)) {
                 clickedBlock.setType(Material.AIR);
+                arenaBlocks.getCuboidArea().removeSafeBlock(clickedBlock);
             }
             return;
         }
@@ -518,10 +523,15 @@ public class Arena implements Listener {
         if (!event.getEntity().hasMetadata("FIL"))
             return;
         event.setCancelled(true);
+
+        if (event.getEntity().hasMetadata("FakeTNT"))
+            return;
+
         for (Block block : blocksToBeDestroyed) {
             if (arenaCuboidArea.isInside(block.getLocation())) {
                 if (started) {
                     block.setType(Material.AIR);
+                    arenaBlocks.getCuboidArea().removeSafeBlock(block);
                 }
             }
         }
@@ -742,6 +752,7 @@ public class Arena implements Listener {
             }
         }
         if (playing.size() > 1) {
+            if (degradeOn == 0) return;
             if (elapsedTicks >= startDegradeOn && (elapsedTicks % degradeOn) == 0) {
                 arenaBlocks.degradeBlocks(world, degradeLevel);
                 degradeLevel++;
@@ -896,6 +907,11 @@ public class Arena implements Listener {
         int c = 0;
         if (loadout == null)
             return contents;
+        if (loadout.faketnt > 0) {
+            contents[c] = Loadout.FAKE_TNT_ITEM.clone();
+            contents[c].setAmount(loadout.faketnt);
+            c++;
+        }
         if (loadout.tnt > 0) {
             contents[c] = Loadout.TNT_ITEM.clone();
             contents[c].setAmount(loadout.tnt);
@@ -929,6 +945,11 @@ public class Arena implements Listener {
         if (loadout.steal > 0) {
             contents[c] = Loadout.STEAL_ITEM.clone();
             contents[c].setAmount((loadout.steal));
+            c++;
+        }
+        if (loadout.randomTp > 0) {
+            contents[c] = Loadout.RANDOM_TP_ITEM.clone();
+            contents[c].setAmount((loadout.randomTp));
         }
         return contents;
     }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
@@ -444,7 +444,7 @@ public class Arena implements Listener {
             Location clicked = clickedBlock.getLocation();
             if (arenaBlocks.getCuboidArea().isInside(clicked)) {
                 clickedBlock.setType(Material.AIR);
-                arenaBlocks.getCuboidArea().removeSafeBlock(clickedBlock);
+                arenaBlocks.getCuboidArea().removeSafeBlock(clickedBlock, false);
             }
             return;
         }
@@ -531,7 +531,7 @@ public class Arena implements Listener {
             if (arenaCuboidArea.isInside(block.getLocation())) {
                 if (started) {
                     block.setType(Material.AIR);
-                    arenaBlocks.getCuboidArea().removeSafeBlock(block);
+                    arenaBlocks.getCuboidArea().removeSafeBlock(block, false);
                 }
             }
         }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/Arena.java
@@ -300,7 +300,8 @@ public class Arena implements Listener {
         arenaCuboidArea = new CuboidArea(
                 config.getConfigurationSection("ArenaArea.One"),
                 config.getConfigurationSection("ArenaArea.Two"),
-                config.get("WorldName").toString());
+                config.get("WorldName").toString(),
+                true);
 
         perkHandler = new PerkHandler(arenaCuboidArea, plugin);
         voteHandler = new VoteHandler();
@@ -308,7 +309,8 @@ public class Arena implements Listener {
         watchCuboidArea = new CuboidArea(
                 config.getConfigurationSection("WaitArea.One"),
                 config.getConfigurationSection("WaitArea.Two"),
-                config.get("WorldName").toString());
+                config.get("WorldName").toString(),
+                false);
 
         arenaBlocks = new ArenaBlocks(arenaCuboidArea);
     }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
@@ -56,6 +56,7 @@ public class ArenaBlocks {
         for (BlockState state : blockStates)
             state.update(true);
         blockStates.clear();
+        getCuboidArea().restoreSavedBlocks();
     }
 
     public void degradeBlocks(World world, int amount) {

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
@@ -67,13 +67,13 @@ public class ArenaBlocks {
                 if (i == (lower.x() + amount) || i == (upper.x() - amount) || j == (lower.z() + amount) || j == (upper.z() - amount)) {
                     for (int k = lower.y(); k <= upper.y(); ++k) {
                         world.getBlockAt(i, k, j).setType(Material.AIR);
-                        getCuboidArea().removeSafeBlock(world.getBlockAt(i, k, j));
+                        getCuboidArea().removeSafeBlock(world.getBlockAt(i, k, j), true);
                     }
                 }
                 if (topDecay) {
                     int y = upper.y() - amount / 2;
                     world.getBlockAt(i, y, j).setType(Material.AIR);
-                    getCuboidArea().removeSafeBlock(world.getBlockAt(i, y, j));
+                    getCuboidArea().removeSafeBlock(world.getBlockAt(i, y, j), true);
                 }
             }
         }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/ArenaBlocks.java
@@ -67,11 +67,13 @@ public class ArenaBlocks {
                 if (i == (lower.x() + amount) || i == (upper.x() - amount) || j == (lower.z() + amount) || j == (upper.z() - amount)) {
                     for (int k = lower.y(); k <= upper.y(); ++k) {
                         world.getBlockAt(i, k, j).setType(Material.AIR);
+                        getCuboidArea().removeSafeBlock(world.getBlockAt(i, k, j));
                     }
                 }
                 if (topDecay) {
                     int y = upper.y() - amount / 2;
                     world.getBlockAt(i, y, j).setType(Material.AIR);
+                    getCuboidArea().removeSafeBlock(world.getBlockAt(i, y, j));
                 }
             }
         }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/FakeTNT.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/FakeTNT.java
@@ -1,0 +1,57 @@
+package com.gmail.tracebachi.floorislava.arena.perks;
+
+import com.gmail.tracebachi.floorislava.FloorIsLavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.util.Vector;
+
+import java.util.Objects;
+import java.util.logging.Level;
+
+public class FakeTNT extends Perk{
+
+    private final FloorIsLavaPlugin plugin;
+
+    public FakeTNT(FloorIsLavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onPerkActivation(PlayerInteractEvent e, PlayerInteractEntityEvent entityEvent) {
+        if (e == null)
+            return false;
+        Bukkit.getLogger().log(Level.SEVERE, "Called!");
+        if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            Location location = Objects.requireNonNull(e.getClickedBlock(),
+                    "If a block was right clicked, why'd this be null?").getLocation();
+            TNTPrimed tnt = e.getPlayer().getWorld().spawn(location.add(0, 1, 0), TNTPrimed.class);
+            tnt.setMetadata("FIL", new FixedMetadataValue(plugin, "FIL"));
+            tnt.setMetadata("FakeTNT", new FixedMetadataValue(plugin, "FIL"));
+        } else if (e.getAction() == Action.RIGHT_CLICK_AIR) {
+            Location location = e.getPlayer().getLocation();
+            TNTPrimed tnt = e.getPlayer().getWorld().spawn(location.add(0, 1, 0), TNTPrimed.class);
+            tnt.setMetadata("FIL", new FixedMetadataValue(plugin, "FIL"));
+            tnt.setMetadata("FakeTNT", new FixedMetadataValue(plugin, true));
+            Vector vector = e.getPlayer().getLocation().getDirection();
+            vector.add(new Vector(0.0, 0.15, 0.0));
+            tnt.setVelocity(vector);
+        }
+        return true;
+    }
+
+    @Override
+    public Material getItem() {
+        return Material.REDSTONE_LAMP;
+    }
+
+    @Override
+    public String getCooldownMessage() {
+        return "You cannot throw fake TNT yet.";
+    }
+}

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/FakeTNT.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/FakeTNT.java
@@ -26,7 +26,6 @@ public class FakeTNT extends Perk{
     public boolean onPerkActivation(PlayerInteractEvent e, PlayerInteractEntityEvent entityEvent) {
         if (e == null)
             return false;
-        Bukkit.getLogger().log(Level.SEVERE, "Called!");
         if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
             Location location = Objects.requireNonNull(e.getClickedBlock(),
                     "If a block was right clicked, why'd this be null?").getLocation();

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/PerkHandler.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/PerkHandler.java
@@ -32,6 +32,7 @@ public class PerkHandler {
 
     private void init() {
         this.perks = new HashMap<>();
+        this.add("faketnt", new FakeTNT(plugin));
         this.add("tnt", new TNT(plugin));
         this.add("hook", new Hook(arenaArea));
         this.add("web", new Web(arenaArea));
@@ -39,6 +40,7 @@ public class PerkHandler {
         this.add("boost", new Boost(arenaArea));
         this.add("chikun", new Chikun());
         this.add("steal", new Steal());
+        this.add("randomtp", new RandomTp(arenaArea));
     }
 
     private void add(String name, Perk perk) {

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
@@ -1,6 +1,7 @@
 package com.gmail.tracebachi.floorislava.arena.perks;
 
 import com.gmail.tracebachi.floorislava.utils.CuboidArea;
+import com.gmail.tracebachi.floorislava.utils.Prefixes;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -20,6 +21,13 @@ public class RandomTp extends Perk {
             return false;
 
         Location randomLocation = arenaArea.getRandomSafeLocationInside();
+
+        // When no blocks are left.
+        if (randomLocation == null) {
+            e.getPlayer().sendMessage(Prefixes.BAD + "No solid blocks were found in the arena.");
+            return true;
+        }
+
         e.getPlayer().teleport(new Location(randomLocation.getWorld(), randomLocation.getX() + 0.5, randomLocation.getY() + 1, randomLocation.getZ() + 0.5));
         return true;
     }

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
@@ -1,13 +1,10 @@
 package com.gmail.tracebachi.floorislava.arena.perks;
 
 import com.gmail.tracebachi.floorislava.utils.CuboidArea;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-
-import java.util.logging.Level;
 
 public class RandomTp extends Perk {
 

--- a/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/arena/perks/RandomTp.java
@@ -1,0 +1,39 @@
+package com.gmail.tracebachi.floorislava.arena.perks;
+
+import com.gmail.tracebachi.floorislava.utils.CuboidArea;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.logging.Level;
+
+public class RandomTp extends Perk {
+
+    private final CuboidArea arenaArea;
+
+    public RandomTp(CuboidArea arenaArea) {
+        this.arenaArea = arenaArea;
+    }
+
+    @Override
+    public boolean onPerkActivation(PlayerInteractEvent e, PlayerInteractEntityEvent entityEvent) {
+        if (e == null)
+            return false;
+
+        Location randomLocation = arenaArea.getRandomSafeLocationInside();
+        e.getPlayer().teleport(new Location(randomLocation.getWorld(), randomLocation.getX() + 0.5, randomLocation.getY() + 1, randomLocation.getZ() + 0.5));
+        return true;
+    }
+
+    @Override
+    public Material getItem() {
+        return Material.CHORUS_FRUIT;
+    }
+
+    @Override
+    public String getCooldownMessage() {
+        return "You cannot be teleported yet.";
+    }
+}

--- a/src/main/java/com/gmail/tracebachi/floorislava/gui/FloorGuiMenu.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/gui/FloorGuiMenu.java
@@ -23,7 +23,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -42,6 +41,7 @@ public class FloorGuiMenu {
     public static final ItemStack HELP_ITEM = new ItemStack(Material.MAP);
     public static final ItemStack POINTS_ITEM = new ItemStack(Material.EMERALD);
 
+    public static final ItemStack FAKE_TNT_ITEM = new ItemStack(Material.REDSTONE_LAMP);
     public static final ItemStack TNT_ITEM = new ItemStack(Material.TNT);
     public static final ItemStack HOOK_ITEM = new ItemStack(Material.TRIPWIRE_HOOK);
     public static final ItemStack WEB_ITEM = new ItemStack(Material.COBWEB);
@@ -49,6 +49,7 @@ public class FloorGuiMenu {
     public static final ItemStack BOOST_ITEM = new ItemStack(Material.FEATHER);
     public static final ItemStack CHIKUN_ITEM = new ItemStack(Material.EGG);
     public static final ItemStack STEAL_ITEM = new ItemStack(Material.FLINT_AND_STEEL);
+    public static final ItemStack RANDOM_TP_ITEM = new ItemStack(Material.CHORUS_FRUIT);
 
     private final Arena arena;
     private final Inventory inventory;
@@ -78,6 +79,7 @@ public class FloorGuiMenu {
         int maxPoints = arena.getBooster().isActive() ? 10 : 5;
 
         inventory.setItem(13, cloneWithAmount(POINTS_ITEM, maxPoints - loadout.countSum()));
+        inventory.setItem(18, cloneWithAmount(FAKE_TNT_ITEM, loadout.faketnt));
         inventory.setItem(19, cloneWithAmount(TNT_ITEM, loadout.tnt));
         inventory.setItem(20, cloneWithAmount(HOOK_ITEM, loadout.hook));
         inventory.setItem(21, cloneWithAmount(WEB_ITEM, loadout.web));
@@ -85,6 +87,7 @@ public class FloorGuiMenu {
         inventory.setItem(23, cloneWithAmount(BOOST_ITEM, loadout.boost));
         inventory.setItem(24, cloneWithAmount(CHIKUN_ITEM, loadout.chikun));
         inventory.setItem(25, cloneWithAmount(STEAL_ITEM, loadout.steal));
+        inventory.setItem(26, cloneWithAmount(RANDOM_TP_ITEM, loadout.randomTp));
 
         player.openInventory(inventory);
     }
@@ -147,6 +150,17 @@ public class FloorGuiMenu {
             throw new NullPointerException("The points item meta is null for some reasons.");
         meta.setDisplayName(ChatColor.AQUA + "" + ChatColor.BOLD + "Loadout Points");
         POINTS_ITEM.setItemMeta(meta);
+
+        meta = FAKE_TNT_ITEM.getItemMeta();
+        if (meta == null)
+            throw new NullPointerException("The fake tnt item meta is null for some reasons.");
+        meta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.BOLD + "Throwing Fake TNT ");
+        meta.setLore(Arrays.asList(
+                ChatColor.WHITE + "Throw tnt that won't explode at",
+                ChatColor.WHITE + "players by right clicking it!",
+                ChatColor.YELLOW + "Left Click: Add",
+                ChatColor.YELLOW + "Right Click: Remove"));
+        FAKE_TNT_ITEM.setItemMeta(meta);
 
         meta = TNT_ITEM.getItemMeta();
         if (meta == null)
@@ -225,5 +239,17 @@ public class FloorGuiMenu {
                 ChatColor.YELLOW + "Left Click: Add",
                 ChatColor.YELLOW + "Right Click: Remove"));
         STEAL_ITEM.setItemMeta(meta);
+
+        meta = RANDOM_TP_ITEM.getItemMeta();
+        if (meta == null)
+            throw new NullPointerException("The random tp item meta is null for some reasons.");
+        meta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.BOLD + "Random Teleport");
+        meta.setLore(Arrays.asList(
+                ChatColor.WHITE + "You will be teleported to",
+                ChatColor.WHITE + "a random block in the arena",
+                ChatColor.WHITE + "whenever you need to!",
+                ChatColor.YELLOW + "Left Click: Add",
+                ChatColor.YELLOW + "Right Click: Remove"));
+        RANDOM_TP_ITEM.setItemMeta(meta);
     }
 }

--- a/src/main/java/com/gmail/tracebachi/floorislava/gui/FloorGuiMenuListener.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/gui/FloorGuiMenuListener.java
@@ -113,10 +113,20 @@ public class FloorGuiMenuListener implements Listener {
             return;
         }
 
-        if (matchesItemStack(FloorGuiMenu.TNT_ITEM, clickedItem)) {
+        if (matchesItemStack(FloorGuiMenu.FAKE_TNT_ITEM, clickedItem)) {
+            int oldCount = loadout.faketnt;
+            loadout.faketnt = Math.max(0, loadout.faketnt + change);
+            playSoundOnCondition(player, loadout.faketnt != oldCount);
+
+            int pointsAmount = maxPoints - loadout.countSum();
+            if (pointsAmount == 0) pointsAmount = 1;
+            updateItemStackAmount(inventory, FloorGuiMenu.POINTS_ITEM, 13, pointsAmount);
+            updateItemStackAmount(inventory, FloorGuiMenu.FAKE_TNT_ITEM, 18, loadout.faketnt);
+        } else if (matchesItemStack(FloorGuiMenu.TNT_ITEM, clickedItem)) {
             int oldCount = loadout.tnt;
             loadout.tnt = Math.max(0, loadout.tnt + change);
             playSoundOnCondition(player, loadout.tnt != oldCount);
+
             int pointsAmount = maxPoints - loadout.countSum();
             if (pointsAmount == 0) pointsAmount = 1;
             updateItemStackAmount(inventory, FloorGuiMenu.POINTS_ITEM, 13, pointsAmount);
@@ -175,6 +185,15 @@ public class FloorGuiMenuListener implements Listener {
             if (pointsAmount == 0) pointsAmount = 1;
             updateItemStackAmount(inventory, FloorGuiMenu.POINTS_ITEM, 13, pointsAmount);
             updateItemStackAmount(inventory, FloorGuiMenu.STEAL_ITEM, 25, loadout.steal);
+        } else if (matchesItemStack(FloorGuiMenu.RANDOM_TP_ITEM, clickedItem)) {
+            int oldCount = loadout.randomTp;
+            loadout.randomTp = Math.max(0, loadout.randomTp + change);
+            playSoundOnCondition(player, loadout.randomTp != oldCount);
+
+            int pointsAmount = maxPoints - loadout.countSum();
+            if (pointsAmount == 0) pointsAmount = 1;
+            updateItemStackAmount(inventory, FloorGuiMenu.POINTS_ITEM, 13, pointsAmount);
+            updateItemStackAmount(inventory, FloorGuiMenu.RANDOM_TP_ITEM, 26, loadout.randomTp);
         }
     }
 

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
@@ -128,7 +128,7 @@ public class CuboidArea {
 
         // Starting from the block below from the broken block, check if it's solid. If it is, add it to the
         // safe blocks list. If it isn't, don't do anything.
-        for (int y = block.getY() - 1; y >= lower.y(); y++) {
+        for (int y = block.getY() - 1; y >= lower.y(); y--) {
             Block blockBelow = block.getWorld().getBlockAt(block.getX(), y, block.getZ());
             if (blockBelow.getType().isSolid()) {
                 safeBlocks.add(blockBelow.getLocation());

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
@@ -39,7 +39,7 @@ public class CuboidArea {
     private List<Location> savedSafeBlocks = new ArrayList<>();
     private List<Location> safeBlocks = new ArrayList<>();
 
-    public CuboidArea(ConfigurationSection alpha, ConfigurationSection beta, String worldName) {
+    public CuboidArea(ConfigurationSection alpha, ConfigurationSection beta, String worldName, boolean addSafeBlocks) {
         Preconditions.checkNotNull(alpha, "Point was null.");
         Preconditions.checkNotNull(beta, "Point was null.");
 
@@ -64,16 +64,18 @@ public class CuboidArea {
         upper = new Point(highestX, highestY, highestZ);
         lower = new Point(lowestX, lowestY, lowestZ);
 
-        for (int x = lowestX; x <= highestX; x++) {
-            for (int z = lowestZ; z <= highestZ; z++ ) {
-                for (int y = highestY; y >= lowestY; y--) {
-                    if (!world.getBlockAt(x, y, z).getType().isSolid()) {
-                        continue;
-                    }
+        if (addSafeBlocks) {
+            for (int x = lowestX; x <= highestX; x++) {
+                for (int z = lowestZ; z <= highestZ; z++ ) {
+                    for (int y = highestY; y >= lowestY; y--) {
+                        if (!world.getBlockAt(x, y, z).getType().isSolid()) {
+                            continue;
+                        }
 
-                    savedSafeBlocks.add(new Location(world, x, y ,z));
-                    safeBlocks.add(new Location(world, x, y, z));
-                    break;
+                        savedSafeBlocks.add(new Location(world, x, y ,z));
+                        safeBlocks.add(new Location(world, x, y, z));
+                        break;
+                    }
                 }
             }
         }

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
@@ -36,6 +36,7 @@ public class CuboidArea {
 
     private Point upper;
     private Point lower;
+    private List<Location> savedSafeBlocks = new ArrayList<>();
     private List<Location> safeBlocks = new ArrayList<>();
 
     public CuboidArea(ConfigurationSection alpha, ConfigurationSection beta, String worldName) {
@@ -70,6 +71,7 @@ public class CuboidArea {
                         continue;
                     }
 
+                    savedSafeBlocks.add(new Location(world, x, y ,z));
                     safeBlocks.add(new Location(world, x, y, z));
                     break;
                 }
@@ -108,15 +110,34 @@ public class CuboidArea {
     }
 
     public Location getRandomLocationInside(World world) {
+        int randomX;
+        int randomZ;
+
+        if (upper.x() == lower.x()) {
+            randomX = upper.x();
+        } else {
+            randomX = lower.x() + 1 + RANDOM.nextInt(upper.x() - lower.x() - 1);
+        }
+
+        if (upper.z() == lower.z()) {
+            randomZ = upper.z();
+        } else {
+            randomZ = lower.z() + 1 + RANDOM.nextInt(upper.z() - lower.z() - 1);
+        }
+
         return new Location(
                 world,
-                lower.x() + 1 + RANDOM.nextInt(upper.x() - lower.x() - 1) + 0.5,
+                randomX + 0.5,
                 upper.y() - 1,
-                lower.z() + 1 + RANDOM.nextInt(upper.z() - lower.z() - 1) + 0.5
+                randomZ + 0.5
         );
     }
 
     public Location getRandomSafeLocationInside() {
+        if (safeBlocks.size() == 0) {
+            return null;
+        }
+
         return safeBlocks.get(new Random().nextInt(safeBlocks.size()));
     }
 
@@ -135,5 +156,10 @@ public class CuboidArea {
                 break;
             }
         }
+    }
+
+    // Use this when an arena ends. Otherwise, blocks broken in a game won't count as safe blocks in next game.
+    public void restoreSavedBlocks() {
+        safeBlocks = new ArrayList<>(savedSafeBlocks);
     }
 }

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/CuboidArea.java
@@ -120,12 +120,20 @@ public class CuboidArea {
         return safeBlocks.get(new Random().nextInt(safeBlocks.size()));
     }
 
-    public void removeSafeBlock(Block block) {
+    public void removeSafeBlock(Block block, boolean removedByDegradation) {
         safeBlocks.remove(block.getLocation());
 
-        Block blockBelow = block.getWorld().getBlockAt(block.getX(), block.getY() -1, block.getZ());
-        if (blockBelow.getType().isSolid()) {
-            safeBlocks.add(blockBelow.getLocation());
+        // If the block was removed because the arena shrunk, it won't loop through the blocks below.
+        if (removedByDegradation) return;
+
+        // Starting from the block below from the broken block, check if it's solid. If it is, add it to the
+        // safe blocks list. If it isn't, don't do anything.
+        for (int y = block.getY() - 1; y >= lower.y(); y++) {
+            Block blockBelow = block.getWorld().getBlockAt(block.getX(), y, block.getZ());
+            if (blockBelow.getType().isSolid()) {
+                safeBlocks.add(blockBelow.getLocation());
+                break;
+            }
         }
     }
 }

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/ItemUseDelay.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/ItemUseDelay.java
@@ -29,6 +29,7 @@ public class ItemUseDelay {
 
     public ItemUseDelay(FileConfiguration config) {
         this.delays = new HashMap<>();
+        this.set("faketnt", config.getInt("ItemUseDelays.FakeTNT"));
         this.set("tnt", config.getInt("ItemUseDelays.ThrowingTNT"));
         this.set("hook", config.getInt("ItemUseDelays.PlayerLauncher"));
         this.set("web", config.getInt("ItemUseDelays.Webber"));
@@ -36,6 +37,7 @@ public class ItemUseDelay {
         this.set("boost", config.getInt("ItemUseDelays.Boost"));
         this.set("chikun", config.getInt("ItemUseDelays.Chikun"));
         this.set("steal", config.getInt("ItemUseDelays.Steal"));
+        this.set("randomtp", config.getInt("ItemUseDelays.RandomTp"));
     }
 
     public long valueOf(String name) {

--- a/src/main/java/com/gmail/tracebachi/floorislava/utils/Loadout.java
+++ b/src/main/java/com/gmail/tracebachi/floorislava/utils/Loadout.java
@@ -27,6 +27,7 @@ import static org.bukkit.ChatColor.*;
  */
 public class Loadout {
 
+    public static final ItemStack FAKE_TNT_ITEM = new ItemStack(Material.REDSTONE_LAMP);
     public static final ItemStack TNT_ITEM = new ItemStack(Material.TNT);
     public static final ItemStack HOOK_ITEM = new ItemStack(Material.TRIPWIRE_HOOK);
     public static final ItemStack WEB_ITEM = new ItemStack(Material.COBWEB);
@@ -34,8 +35,15 @@ public class Loadout {
     public static final ItemStack BOOST_ITEM = new ItemStack(Material.FEATHER);
     public static final ItemStack CHIKUN_ITEM = new ItemStack(Material.EGG);
     public static final ItemStack STEAL_ITEM = new ItemStack(Material.FLINT_AND_STEEL);
+    public static final ItemStack RANDOM_TP_ITEM = new ItemStack(Material.CHORUS_FRUIT);
 
     static {
+        ItemMeta fakeTntMeta = FAKE_TNT_ITEM.getItemMeta();
+        if (fakeTntMeta == null)
+            throw new NullPointerException("The fake TNT item meta is null for some reasons.");
+        fakeTntMeta.setDisplayName(GOLD + "Fake TNT");
+        FAKE_TNT_ITEM.setItemMeta(fakeTntMeta);
+
         ItemMeta tntMeta = TNT_ITEM.getItemMeta();
         if (tntMeta == null)
             throw new NullPointerException("The tnt item meta is null for some reasons.");
@@ -79,8 +87,15 @@ public class Loadout {
             throw new NullPointerException("The steal item meta is null for some reasons.");
         stealMeta.setDisplayName(BLUE + "Steal");
         STEAL_ITEM.setItemMeta(stealMeta);
+
+        ItemMeta randomTpMeta = RANDOM_TP_ITEM.getItemMeta();
+        if (randomTpMeta == null)
+            throw new NullPointerException("The random tp item meta is null for some reasons.");
+        randomTpMeta.setDisplayName(DARK_PURPLE + "Random Teleport");
+        RANDOM_TP_ITEM.setItemMeta(randomTpMeta);
     }
 
+    public int faketnt;
     public int tnt;
     public int hook;
     public int web;
@@ -88,8 +103,10 @@ public class Loadout {
     public int boost;
     public int chikun;
     public int steal;
+    public int randomTp;
 
     public Loadout() {
+        faketnt = 0;
         tnt = 0;
         hook = 0;
         web = 0;
@@ -97,9 +114,10 @@ public class Loadout {
         boost = 0;
         chikun = 0;
         steal = 0;
+        randomTp = 0;
     }
 
     public int countSum() {
-        return tnt + hook + web + invis + boost + chikun + steal;
+        return faketnt + tnt + hook + web + invis + boost + chikun + steal + randomTp;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,7 @@ BoosterBroadcastRange: 100
 
 # Delays in milliseconds between item uses
 ItemUseDelays:
+  FakeTNT: 5000
   ThrowingTNT: 5000
   PlayerLauncher: 5000
   Webber: 5000
@@ -28,6 +29,7 @@ ItemUseDelays:
   Boost: 5000
   Chikun: 5000
   Steal: 5000
+  RandomTp: 5000
 
 # Points make up the cuboid where players can break blocks
 # Being outside this cuboid will leave players from the arena


### PR DESCRIPTION
(From Dol's suggestions at the end of the main file)

Fake TNT is the same as the normal TNT perk but it won't explode at the end and the random teleport perk will teleport you to any random and solid block inside the arena.

The cuboid area has a new property which is the list of "safe blocks" in the arena. These are existing solid blocks where the player can be teleported. When a block is broken by a player, TNT or arena shrinking, the block is removed from the list.

Also, the plugin won't throw an error if the "DegradeOnTick" is 0.